### PR TITLE
added very rudimentary hack to get nested mapping to work from source

### DIFF
--- a/src/Wayless/Helpers.cs
+++ b/src/Wayless/Helpers.cs
@@ -33,7 +33,12 @@ namespace Wayless
         {
             var lambda = expression as LambdaExpression;
             MemberExpression memberExpression = null;
-            if (lambda.Body is UnaryExpression)
+
+            if (lambda.Body.NodeType == ExpressionType.MemberAccess)
+            {
+                return ((MemberExpression)lambda.Body).Member as PropertyInfo;
+            }
+            else if (lambda.Body is UnaryExpression)
             {
                 memberExpression = (lambda.Body as UnaryExpression)?.Operand as MemberExpression;
             }


### PR DESCRIPTION
This "fix" temporarily works since we are using Func<T, object> which results in a NodType of Convert, unless we're dealing with explicitly declared members of type Object. This adds a little overhead since we're invoking on members, but it allows us to do something like 

```
bjectMapperService.SetRules<Category, Product>(cfg =>
{
   cfg.FieldMap(d => d.CategoryId, s => s.ProductId)
   .FieldMap(d => d.CName, s => s.Category.NestedCategory.NestedCategory.CName);
});
```